### PR TITLE
Revert "Bump maven-surefire-plugin from 3.0.0-M4 to 3.0.0-M5"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.0.0-M5</version>
+          <version>3.0.0-M4</version>
         </plugin>
         <plugin>
           <artifactId>maven-deploy-plugin</artifactId>


### PR DESCRIPTION
There is a breaking change that tries to add support for multiple test runners but admittingly it fails to find any junit tests.

Reverts Specshell/specshell.software.maven.pom#10