### PR TITLE
use release flag instead of source/target

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,18 +9,13 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: "!contains(github.event.head_commit.message, 'ci skip')"
     steps:
     - name: Checkout
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
-
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
-      with:
-        java-version: 1.8
 
     - uses: s4u/maven-settings-action@v2.2.0
       with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,14 +6,9 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
-
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
-      with:
-        java-version: 1.8
 
     - uses: s4u/maven-settings-action@v2.2.0
       with:

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,6 @@
   <properties>
     <maven.javadoc.skip>true</maven.javadoc.skip>
     <java.level>8</java.level>
-    <java.test.level>${java.level}</java.test.level>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -110,10 +109,7 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.${java.level}</source>
-          <target>1.${java.level}</target>
-          <testSource>1.${java.test.level}</testSource>
-          <testTarget>1.${java.test.level}</testTarget>
+          <release>${java.level}</release>
           <proc>none</proc>
         </configuration>
       </plugin>


### PR DESCRIPTION
The release flag requires a Java 9 or newer JDK. So I would suggest that you all update to Java 11 JDK.
We can currently already build with Java 11 JDK and target Java 8 runtime as we currently do through `source` and `target` flag.
Please approve the PR once you have upgraded to Java 11.

If you have chocolatey you can run the command below, as it should update JAVA home accordingly.
```
choco install AdoptOpenJDK11 --params="/ADDLOCAL=FeatureMain,FeatureEnvironment,FeatureJarFileRunWith,FeatureJavaHome"
```

This should also help prepare for https://github.com/actions/virtual-environments/issues/1816 once Java 11 JDK is the new default on GitHub actions.

https://www.baeldung.com/maven-java-version#java9