### PR TITLE
add hamcrest-core as a default test package

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
hamcrest comes with `assertThat` and matchers library to make it easier writing tests